### PR TITLE
Fixes repository name in deployment script

### DIFF
--- a/infra/script/deployment.ts
+++ b/infra/script/deployment.ts
@@ -39,7 +39,7 @@ async function createPullRequestComment(comment: string) {
 
   try {
     const res = await fetch(
-      `https://api.github.com/repos/souzagabriel26/student-identification/issues/${pullRequestNumber}/comments`,
+      `https://api.github.com/repos/souzagabriel26/decentralized-student-identification/issues/${pullRequestNumber}/comments`,
       {
         method: 'POST',
         headers: {


### PR DESCRIPTION
## Context
- I changed the repository name from `student-identification` to `decentralized-student-identification`, but I forgot to update the `deployment` script